### PR TITLE
Add Python 3.14 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.12", "3.13"]
+        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
### Motivation
- Ensure automated checks run against the upcoming interpreter by adding Python 3.14 to the CI matrix so regressions are caught early.

### Description
- Updated the CI workflow matrix in `.github/workflows/ci.yml` to include `"3.14"` alongside `"3.12"` and `"3.13"`.

### Testing
- No local tests were run because this is a CI-only change; the workflow will execute the full test matrix (3.12, 3.13, 3.14) when the pipeline runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69707e21a8e88322ab37ec26b2088f07)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Added Python 3.14 to the CI test matrix to ensure compatibility with the upcoming Python release and catch regressions early.

- Extended the matrix in `.github/workflows/ci.yml` to include `"3.14"` alongside existing `"3.12"` and `"3.13"`
- All CI steps (dependency installation, linting, type checking, testing) will now run against Python 3.14
- The change is minimal and correctly implements the stated goal of proactive testing

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with minimal risk
- The change is a single-line addition to the CI matrix that adds Python 3.14 testing. The modification is low-risk, well-scoped, and aligns with best practices for proactive compatibility testing. No code logic or dependencies are affected.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Added Python 3.14 to CI test matrix; configuration tools still target 3.12 which may cause inconsistencies |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub Actions
    participant Matrix as CI Matrix
    participant uv as UV Package Manager
    participant Tools as Linting/Testing Tools

    Dev->>GH: Push commit or create PR
    GH->>Matrix: Trigger CI workflow
    
    par Python 3.12
        Matrix->>uv: Setup Python 3.12
        uv->>Tools: Install dependencies
        Tools->>Tools: Run ruff check
        Tools->>Tools: Run ruff format (py312 target)
        Tools->>Tools: Run basedpyright
        Tools->>Tools: Run pytest
        Tools->>GH: Upload coverage report
    and Python 3.13
        Matrix->>uv: Setup Python 3.13
        uv->>Tools: Install dependencies
        Tools->>Tools: Run ruff check
        Tools->>Tools: Run ruff format (py312 target)
        Tools->>Tools: Run basedpyright
        Tools->>Tools: Run pytest
        Tools->>GH: Upload coverage report
    and Python 3.14
        Matrix->>uv: Setup Python 3.14
        uv->>Tools: Install dependencies
        Tools->>Tools: Run ruff check
        Tools->>Tools: Run ruff format (py312 target)
        Tools->>Tools: Run basedpyright
        Tools->>Tools: Run pytest
        Tools->>GH: Upload coverage report
    end
    
    GH->>Dev: Report CI results
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->