### PR TITLE
Support Mojang year-based version strings

### DIFF
--- a/squid/utils.py
+++ b/squid/utils.py
@@ -8,7 +8,7 @@ import aiohttp
 
 from squid.db.schema import Version
 
-VERSION_PATTERN = re.compile(r"^\W*(Java|Bedrock)? ?(\d+)\.(\d+)\.(\d+)\W*$", re.IGNORECASE)
+VERSION_PATTERN = re.compile(r"^\W*(Java|Bedrock)? ?(\d+)\.(\d+)(?:\.(\d+))?\W*$", re.IGNORECASE)
 
 
 def utcnow() -> str:
@@ -52,7 +52,7 @@ def parse_version_string(version_string: str) -> tuple[Literal["Java", "Bedrock"
     """Parses a version string into its components. Defaults to Java edition if no edition is specified in the string.
 
     A version string is formatted as follows:
-    ["Java" | "Bedrock"] major_version.minor_version.patch_number
+    ["Java" | "Bedrock"] major_version.minor_version[.patch_number]
     """
 
     match = VERSION_PATTERN.match(version_string)
@@ -61,7 +61,7 @@ def parse_version_string(version_string: str) -> tuple[Literal["Java", "Bedrock"
         raise ValueError(msg)
 
     edition, major, minor, patch = match.groups()
-    return edition or "Java", int(major), int(minor), int(patch)  # type: ignore
+    return edition or "Java", int(major), int(minor), int(patch or 0)  # type: ignore
 
 
 def parse_time_string(time_string: str | None) -> int | None:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from squid.utils import parse_time_string
+from squid.utils import parse_time_string, parse_version_string
 
 
 @pytest.mark.parametrize(
@@ -18,4 +18,18 @@ from squid.utils import parse_time_string
 def test_parse_time_string(time_string: str | None, expected: int | None):
     """Test time string parsing with various formats."""
     result = parse_time_string(time_string)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("version_string", "expected"),
+    [
+        ("Java 26.0", ("Java", 26, 0, 0)),
+        ("Bedrock 26.1", ("Bedrock", 26, 1, 0)),
+        ("26.1.3", ("Java", 26, 1, 3)),
+    ],
+)
+def test_parse_version_string(version_string: str, expected: tuple[str, int, int, int]):
+    """Test version string parsing supports both year and patch release formats."""
+    result = parse_version_string(version_string)
     assert result == expected


### PR DESCRIPTION
### Motivation
- Mojang switched to year-based `major.minor` versioning for both Java and Bedrock (e.g. `26.0`, `26.1`), and the existing parser required a three-part `major.minor.patch` format which caused new tracker messages and manual add-version commands to be rejected.

### Description
- Make the patch segment optional by updating `VERSION_PATTERN` to accept either `major.minor` or `major.minor.patch` and normalize a missing patch to `0` in `parse_version_string` so the existing schema stays compatible.
- Update the parser docstring to document the accepted `major.minor[.patch_number]` format and add unit tests in `tests/unit/test_utils.py` that cover `Java 26.0`, `Bedrock 26.1`, and a three-part example `26.1.3`.

### Testing
- Ran `ruff format squid/utils.py tests/unit/test_utils.py --target-version py312`, which completed successfully.
- Ran `pytest tests/unit/test_utils.py tests/unit/test_database_manager.py -q`, which failed in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'dotenv'` from `tests/conftest.py`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbd4ba53648322a3275264fd7eae92)