### PR TITLE
Refactor CI workflow into separate lint, typecheck, and test jobs and standardize Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,11 +13,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  ci:
+  lint-and-format:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -33,7 +30,7 @@ jobs:
     - name: "Set up Python"
       uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: "3.12"
 
     - name: Install the project
       run: uv sync --all-extras --dev
@@ -53,8 +50,59 @@ jobs:
     - name: See if there are formatting issues
       run: uv run ruff format --target-version py312 --check
 
+    - name: Minimize uv cache
+      run: uv cache prune --ci
+
+  typecheck:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      with:
+        version: "0.11.2"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: "Set up Python"
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: "3.12"
+
+    - name: Install the project
+      run: uv sync --all-extras --dev
+
     - name: See if there are type checking issues
       run: uv run basedpyright --level=warning
+
+    - name: Minimize uv cache
+      run: uv cache prune --ci
+
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      with:
+        version: "0.11.2"
+        enable-cache: true
+        cache-dependency-glob: "uv.lock"
+
+    - name: "Set up Python"
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install the project
+      run: uv sync --all-extras --dev
 
     - name: Run tests
       run: uv run pytest tests --cov=squid --cov-report=term-missing --cov-report=html


### PR DESCRIPTION
### Motivation
- Improve CI clarity and performance by separating lint/format checks, type checking, and test runs into distinct jobs.
- Standardize the default Python runtime to `3.12` for tooling jobs while preserving a multi-version matrix for test execution.

### Description
- Split the single `ci` job into three jobs: `lint-and-format`, `typecheck`, and `tests` with appropriate steps for each job.
- Pin the tooling jobs to `python-version: "3.12"` and keep a test matrix over `3.12`, `3.13`, and `3.14` for the `tests` job.
- Reuse `actions/checkout`, `astral-sh/setup-uv`, and `actions/setup-python` in each job and run `uv sync --all-extras --dev` to install dependencies.
- Add `uv cache prune --ci` at the end of jobs to minimize the `uv` cache after runs.

### Testing
- The lint and format checks are configured to run `uv run ruff check --extend-select I` and `uv run ruff format --target-version py312 --check` and are executed by the `lint-and-format` job; no execution results are included in this change.
- The type checker is configured to run `uv run basedpyright --level=warning` in the `typecheck` job; no execution results are included in this change.
- Tests are configured to run `uv run pytest tests --cov=squid --cov-report=term-missing --cov-report=html` across the Python matrix in the `tests` job; no execution results are included in this change.
- Coverage artifacts are uploaded with `actions/upload-artifact` from the `tests` job and `uv cache prune --ci` is run after each job; no execution results are included in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cc8e5c9fb8832296d0690dbc2fc359)